### PR TITLE
Fix Linux build

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -3,6 +3,7 @@
 #include "Iex.h"
 #endif
 #include <stdio.h>
+#include <string.h>
 
 MyIStream::MyIStream(const char* fileName)
 	:

--- a/src/image_jxl.cpp
+++ b/src/image_jxl.cpp
@@ -5,6 +5,8 @@
 
 #include "image_jxl.h"
 
+#include <string.h>
+
 static JxlThreadParallelRunnerPtr s_jxl_runner;
 
 void InitJxl(int thread_count)

--- a/src/image_mop.cpp
+++ b/src/image_mop.cpp
@@ -6,6 +6,8 @@
 #define IC_PFOR_IMPLEMENTATION
 #include "ic_pfor.h"
 
+#include <string.h>
+
 constexpr size_t kChunkSize = 16 * 1024;
 
 void InitMop(int thread_count)

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -8,6 +8,10 @@
 #ifdef _MSC_VER
 #include <windows.h>
 #endif
+#ifdef __linux
+#include <string.h>
+#include <stdio.h>
+#endif
 
 std::string sysinfo_getplatform()
 {
@@ -15,6 +19,8 @@ std::string sysinfo_getplatform()
     return "macOS";
     #elif defined _MSC_VER
     return "Windows";
+    #elif defined __linux
+    return "Linux";
     #else
     #error Unknown platform
     #endif
@@ -46,6 +52,27 @@ std::string sysinfo_getcpumodel()
 		}
 	}
 	return "Unknown";
+    #elif defined __linux
+	std::string result = "Unknown";
+
+	FILE* file = fopen("/proc/cpuinfo", "r");
+	if (!file)
+		return result;
+
+	char line[1024];
+	while (fgets(line, sizeof(line), file))
+	{
+		if (strncmp(line, "model name\t: ", 13) == 0)
+		{
+			result = line + 13;
+			if (!result.empty() && result.back() == '\n')
+				result.pop_back();
+			break;
+		}
+	}
+
+	fclose(file);
+	return result;
     #else
     #error Unknown platform
     #endif


### PR DESCRIPTION
Add missing string.h includes for mem* functions and provide Linux specific code to query CPU model name.