### PR TITLE
Use std::unique_ptr constructor instead of make_unique

### DIFF
--- a/src/image_exr.cpp
+++ b/src/image_exr.cpp
@@ -35,7 +35,7 @@ bool LoadExrFile(MyIStream &mem, Image& r_image)
     }
     
     r_image.pixels_size = r_image.width * r_image.height * offset;
-    r_image.pixels = std::make_unique<char[]>(r_image.pixels_size);
+    r_image.pixels.reset(new char[r_image.pixels_size]);
     
     Imf::FrameBuffer fb;
     for (const auto& ch : r_image.channels) {

--- a/src/image_jxl.cpp
+++ b/src/image_jxl.cpp
@@ -115,12 +115,12 @@ bool LoadJxlFile(MyIStream &mem, Image& r_image)
             total_buffer_size = r_image.width * r_image.height * offset;
             if (extra_non_alpha_channels == 0)
             {
-                r_image.pixels = std::make_unique<char[]>(total_buffer_size);
+                r_image.pixels.reset(new char[total_buffer_size]);
                 r_image.pixels_size = total_buffer_size;
             }
             else
             {
-                planar_buffer = std::make_unique<uint8_t[]>(total_buffer_size);
+                planar_buffer.reset(new uint8_t[total_buffer_size]);
             }
         }
         else if (status == JXL_DEC_FRAME)
@@ -202,7 +202,7 @@ bool LoadJxlFile(MyIStream &mem, Image& r_image)
         // into destination, with scattered reads (i.e. order is "for all pixels,
         // for all channels") than it is to do linear reads, scattered writes
         // ("for all channels, for all pixels").
-        r_image.pixels = std::make_unique<char[]>(total_buffer_size);
+        r_image.pixels.reset(new char[total_buffer_size]);
         r_image.pixels_size = total_buffer_size;
         const uint8_t* src_ptr = planar_buffer.get();
         const size_t pixel_stride = total_buffer_size / r_image.width / r_image.height;

--- a/src/image_mop.cpp
+++ b/src/image_mop.cpp
@@ -56,7 +56,7 @@ bool LoadMopFile(MyIStream &mem, Image& r_image)
 
     const size_t pixel_count = r_image.width * r_image.height;
     r_image.pixels_size = pixel_count * pixel_stride;
-    r_image.pixels = std::make_unique<char[]>(r_image.pixels_size);
+    r_image.pixels.reset(new char[r_image.pixels_size]);
 
     size_t chunk_count = (pixel_count + kChunkSize - 1) / kChunkSize;
     const size_t coded_stride = (pixel_stride + 3) / 4 * 4; // mesh optimizer requires stride to be multiple of 4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,7 @@ static bool TestFile(const char* file_path, int run_index)
         {
             img_got.width = img_in.width;
             img_got.height = img_in.height;
-            img_got.pixels = std::make_unique<char[]>(img_in.pixels_size);
+            img_got.pixels.reset(new char[img_in.pixels_size]);
             img_got.pixels_size = img_in.pixels_size;
             memcpy(img_got.pixels.get(), mem_got_in.data(), img_got.pixels_size);
         }


### PR DESCRIPTION
`make_unique<T[]>` overload value-initializes the output elements which makes the performance ~equivalent to std::vector; in C++20 there's now `make_unique_for_overwrite` which achieves the same purpose but really `.reset()` is completely fine.